### PR TITLE
addAll() mukaan lataa()-metodiin

### DIFF
--- a/src/osa8/05-yksikkotestaus.md
+++ b/src/osa8/05-yksikkotestaus.md
@@ -380,6 +380,7 @@ public class Tehtavakokoelma {
     public void lataa() {
         try {
             List<Tehtava> kaikkiTehtavat = repository.lataa();
+            tehtavat.addAll(kaikkiTehtavat);
         } catch (RepositoryException e) {
             IO.println(e.getMessage());
         }


### PR DESCRIPTION
Tämä rivi vaadittiin jotta lukee ja kirjoittaa tehtavat.jsoniin. Muuten ohjelma ei lue eikä tallenna mitään. Oli mukana kappaleen 8.3 lataa()-metodissa, mutta putosiko pois vahingossa?